### PR TITLE
Update version locking for marked to 4.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "express-session": "^1.13.0",
     "forever": "^2.0.0",
     "helmet": "^2.0.0",
-    "marked": "0.3.9",
+    "marked": "4.0.10",
     "mongodb": "^2.1.18",
     "needle": "2.2.4",
     "node-esapi": "0.0.1",


### PR DESCRIPTION
Replace very old version of marked to resolve OSS vulnerability.  